### PR TITLE
Fix db name to match the one in docker-compose.yml.

### DIFF
--- a/LocalSettings.dist.php
+++ b/LocalSettings.dist.php
@@ -53,7 +53,7 @@ $wgEmailAuthentication = false;
 ## Database settings
 $wgDBtype = "mysql";
 $wgDBserver = "mysql";
-$wgDBname = "wiki";
+$wgDBname = "repo";
 $wgDBuser = "root";
 $wgDBpassword = "root";
 


### PR DESCRIPTION
The database we create in `docker-compose.yml` is called "repo", so this is a little confusing :)